### PR TITLE
Fix 'npx tsai-registry build' command

### DIFF
--- a/cli/build.ts
+++ b/cli/build.ts
@@ -8,8 +8,11 @@ import { write } from 'bun';
   const settings = await loadSettings();
   const ignoreExtensions: string[] = settings.build?.ignoreExtensions || [];
 
-  // Racine du dossier registry
-  const REGISTRY_ROOT = path.join(process.cwd(), 'app', 'src', 'mastra', 'registry');
+  // Racine du dossier registry (argument CLI ou valeur par défaut)
+  const registryArg = process.argv[2] || 'app/src/mastra/registry';
+  const REGISTRY_ROOT = path.isAbsolute(registryArg)
+    ? registryArg
+    : path.join(process.cwd(), registryArg);
   const OUTPUT_PATH = path.join(process.cwd(), 'registry.json');
 
   // Types supportés

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -220,8 +220,12 @@ yargs(hideBin(process.argv))
     async (argv) => {
       try {
         const { spawn } = require('child_process');
-        const buildScript = path.join(__dirname, 'build.ts');
-        const proc = spawn('bun', [buildScript], { stdio: 'inherit', env: process.env });
+        const buildScript = path.join(__dirname, 'build.js');
+        const registryArg = argv.registryPath as string;
+        const proc = spawn('bun', [buildScript, registryArg], {
+          stdio: 'inherit',
+          env: process.env,
+        });
         proc.on('close', (code: number) => process.exit(code));
       } catch (e: any) {
         console.error('Erreur lors de la génération du registry:', e.message);

--- a/cli/package.json
+++ b/cli/package.json
@@ -13,7 +13,7 @@
     "settings.json"
   ],
   "scripts": {
-    "build": "bun build index.ts --outdir dist --target bun",
+    "build": "bun build index.ts build.ts --outdir dist --target bun",
     "prepublishOnly": "bun run build"
   },
   "repository": {


### PR DESCRIPTION
## Summary
- compile `build.ts` when building CLI
- call compiled `build.js` inside the build command
- allow registry path argument to be passed from CLI to build script

## Testing
- `bun run build`
- `bun dist/index.js build ../app/src/mastra/registry`
- `yes | npx tsai-registry@0.1.1 build app/src/mastra/registry` *(fails: Module not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb91c585c8331962c4c5697884a8c