### PR TITLE
Add custom settings URL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The AI ecosystem is moving fast, and many Python frameworks (LangChain, CrewAI, 
   ```sh
   npx tsai-registry settings
   ```
+  You can also set the `TSAR_SETTINGS_URL` environment variable to load a custom `settings.json` from another location.
 
 > The default registry is this open source repository. The whole community can contribute and share their agents!
 
@@ -121,6 +122,7 @@ L'écosystème de l'IA évolue rapidement, et de nombreux frameworks Python (Lan
   ```sh
   npx tsai-registry settings
   ```
+  Vous pouvez également définir la variable d'environnement `TSAR_SETTINGS_URL` pour charger un `settings.json` personnalisé depuis un autre emplacement.
 
 > Le registry par défaut est ce dépôt open source. Toute la communauté peut y contribuer pour partager ses agents !
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -39,6 +39,7 @@ The AI ecosystem is moving fast, and many Python frameworks (LangChain, CrewAI, 
   ```sh
   npx tsai-registry settings
   ```
+  You can also set the `TSAR_SETTINGS_URL` environment variable to load a custom `settings.json` from another location.
 
 > The default registry is this open source repository. The whole community can contribute and share their agents!
 
@@ -121,6 +122,7 @@ L'écosystème de l'IA évolue rapidement, et de nombreux frameworks Python (Lan
   ```sh
   npx tsai-registry settings
   ```
+  Vous pouvez également définir la variable d'environnement `TSAR_SETTINGS_URL` pour charger un `settings.json` personnalisé depuis un autre emplacement.
 
 > Le registry par défaut est ce dépôt open source. Toute la communauté peut y contribuer pour partager ses agents !
 

--- a/cli/utils.ts
+++ b/cli/utils.ts
@@ -4,7 +4,8 @@ import path from 'path';
 export async function loadSettings(settingsPath?: string): Promise<any> {
   let data: string;
   if (!settingsPath) {
-    settingsPath = "https://raw.githubusercontent.com/aidalinfo/tsai-registry/refs/heads/main/settings.json";
+    settingsPath = process.env.TSAR_SETTINGS_URL ||
+      "https://raw.githubusercontent.com/aidalinfo/tsai-registry/refs/heads/main/settings.json";
   }
   if (settingsPath.startsWith("http://") || settingsPath.startsWith("https://")) {
     const res = await fetch(settingsPath);


### PR DESCRIPTION
## Summary
- allow overriding default settings.json path with `TSAR_SETTINGS_URL`
- document the new environment variable in the README files

## Testing
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_684d639ce42083319807f986edae46be