### PR TITLE
Add navbar_title support for docs pages

### DIFF
--- a/docs/src/lib/docs-navigation.ts
+++ b/docs/src/lib/docs-navigation.ts
@@ -12,6 +12,7 @@ export interface NavigationItem {
 interface PageFrontmatter {
   title?: string
   description?: string
+  navbar_title?: string
   order?: number
   [key: string]: any
 }
@@ -76,8 +77,12 @@ export const getNavigationItems = (): NavigationItem[] => {
         if (value.__file) {
           // Si c'est la racine de /docs ou un index, on affiche "Introduction"
           const isRootIndex = value.path === '/docs' || value.path === '/docs/index';
+          const navTitle = value.frontmatter.navbar_title ||
+            (isRootIndex
+              ? 'Introduction'
+              : formatTitle(key === 'index' ? (parentPath.split('/').pop() || 'Index') : key));
           return {
-            title: isRootIndex ? 'Introduction' : formatTitle(key === 'index' ? (parentPath.split('/').pop() || 'Index') : key),
+            title: navTitle,
             url: value.path === '/docs/index' ? '/docs' : value.path,
             icon: getIcon(key),
             order: value.frontmatter.order ?? 9999,

--- a/docs/src/pages/docs/contribute.mdx
+++ b/docs/src/pages/docs/contribute.mdx
@@ -1,6 +1,7 @@
 ---
 layout: '@/layouts/docs-mdx.astro'
 title: "Contribute"
+navbar_title: "Contrib"
 order: 3
 description: "Guide to contributing agents to the tsai-registry"
 ---

--- a/docs/src/pages/docs/index.mdx
+++ b/docs/src/pages/docs/index.mdx
@@ -1,6 +1,7 @@
 ---
 layout: '@/layouts/docs-mdx.astro'
 title: "Introduction"
+navbar_title: "Intro"
 order: 1
 description: "Complete guide to using tsai-registry - Collection of Mastra agents and tools"
 ---
@@ -8,6 +9,8 @@ description: "Complete guide to using tsai-registry - Collection of Mastra agent
 # tsai-registry
 
 Welcome to **tsai-registry**, an open-source library of pre-built agents, tools, and workflows for Mastra framework.
+
+> **Note**: You can customize the label displayed in the sidebar by setting `navbar_title` in the frontmatter of your page.
 
 ## 🎯 What is tsai-registry?
 

--- a/docs/src/pages/docs/installation.mdx
+++ b/docs/src/pages/docs/installation.mdx
@@ -1,6 +1,7 @@
 ---
 layout: '@/layouts/docs-mdx.astro'
 title: "Installation"
+navbar_title: "Install"
 order: 2
 description: "Installation guide for tsai-registry"
 ---


### PR DESCRIPTION
## Summary
- support `navbar_title` field in MDX frontmatter for docs navigation
- document this new field in introduction page
- demonstrate usage in example pages

## Testing
- `pnpm test` *(fails: No package.json found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9aaf8ffc8331b7abc89576348b94