### PR TITLE
Remove unused settings-path option

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -10,16 +10,10 @@ yargs(hideBin(process.argv))
   .command(
     'settings',
     'Affiche les paramètres de configuration',
-    (yargs) => {
-      return yargs.option('settings-path', {
-        alias: 's',
-        describe: 'Chemin local ou URL du fichier settings.json',
-        type: 'string',
-      });
-    },
-    async (argv) => {
+    () => {},
+    async () => {
       try {
-        const settings = await loadSettings(argv["settings-path"] as string | undefined);
+        const settings = await loadSettings();
         console.log(JSON.stringify(settings, null, 2));
       } catch (e: any) {
         console.error("Erreur lors du chargement des settings:", e.message);
@@ -35,15 +29,11 @@ yargs(hideBin(process.argv))
         describe: 'Type d\'objet à lister',
         choices: ['agents', 'workflows', 'tools', 'mcp'],
         type: 'string',
-      }).option('settings-path', {
-        alias: 's',
-        describe: 'Chemin local ou URL du fichier settings.json',
-        type: 'string',
       });
     },
     async (argv) => {
       try {
-        const settings = await loadSettings(argv["settings-path"] as string | undefined);
+        const settings = await loadSettings();
         const registryPath = settings.settings?.registry;
         const settingsUrl = settings.settings?.url;
         if (!registryPath) throw new Error("Le chemin du registry n'est pas défini dans les settings.");
@@ -73,16 +63,12 @@ yargs(hideBin(process.argv))
       return yargs.positional('name', {
         describe: "Name of the object to add (e.g., research-agent)",
         type: 'string',
-      }).option('settings-path', {
-        alias: 's',
-        describe: 'Local path or URL to the settings.json file',
-        type: 'string',
       });
     },
     async (argv) => {
       try {
         const name = argv.name as string;
-        const settings = await loadSettings(argv["settings-path"] as string | undefined);
+        const settings = await loadSettings();
         const registryPath = settings.settings?.registry;
         const settingsUrl = settings.settings?.url;
         const localPath = settings.settings?.local;

--- a/docs/src/pages/docs/cli.md
+++ b/docs/src/pages/docs/cli.md
@@ -1,0 +1,89 @@
+---
+layout: '@/layouts/docs-mdx.astro'
+title: "CLI"
+navbar_title: "CLI"
+order: 4
+description: "How to use the tsai-registry CLI"
+---
+
+# tsai-registry CLI
+
+This page describes the available commands of the `tsai-registry` CLI and how they rely on the `settings.json` file.
+
+## General usage
+
+Run commands with `npx`:
+
+```bash
+npx tsai-registry <command>
+```
+
+## Available commands
+
+### `settings`
+
+Display the configuration used by the CLI:
+
+```bash
+npx tsai-registry settings
+```
+
+The configuration is loaded with the `loadSettings` function from `cli/utils.ts`.
+
+### `list [type]`
+
+List objects from the registry. The optional `type` can be `agents`, `workflows`, `tools` or `mcp`.
+
+```bash
+npx tsai-registry list agents
+```
+
+The CLI reads the registry path from `settings.json`, loads `registry.json` and displays the matching entries.
+
+### `add <name>`
+
+Copy an agent, workflow or tool from the registry locally. The command downloads the files listed in `registry.json`, installs the required dependencies and prints environment variables to add.
+
+```bash
+npx tsai-registry add weather-agent
+```
+
+The destination folder is defined by `settings.local` in `settings.json`. If the folder already exists, the CLI asks whether to overwrite it.
+
+### `build [registryPath]`
+
+Generate a `registry.json` file from a local folder containing your agents. The default path is `app/src/mastra/registry`, but you can provide a custom one:
+
+```bash
+npx tsai-registry build ./my-agents
+```
+
+The command iterates through the `agents`, `workflows` and `tools` subfolders and gathers the files needed for each entry. It ignores extensions listed in `build.ignoreExtensions` from `settings.json`.
+
+## `settings.json`
+
+The `settings.json` file centralises the CLI configuration. Example:
+
+```json
+{
+  "settings": {
+    "url": "https://github.com/aidalinfo/tsai-registry",
+    "registry": "registry.json",
+    "local": "src/mastra/registry"
+  },
+  "build": {
+    "ignoreExtensions": [
+      ".md",
+      ".yaml"
+    ]
+  }
+}
+```
+
+- **settings.url**: URL of the default registry repository.
+- **settings.registry**: path to the `registry.json` file to load.
+- **settings.local**: folder where objects added with the `add` command are copied.
+- **build.ignoreExtensions**: file extensions ignored when generating the registry with `build`.
+
+You can set the `TSAR_SETTINGS_URL` environment variable to override the official settings URL. This lets you point the CLI to a different registry repository. If no flag or variable is provided, the CLI falls back to the default URL declared in `cli/utils.ts`.
+


### PR DESCRIPTION
## Summary
- drop the `--settings-path` flag from CLI commands
- update CLI docs accordingly

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684dc69028bc8331ae786cb801f3b7ba