### PR TITLE
Add translation agent

### DIFF
--- a/app/src/mastra/registry/agents/translate-agent/index.ts
+++ b/app/src/mastra/registry/agents/translate-agent/index.ts
@@ -1,0 +1,3 @@
+import { translationAgent } from './translate-agent'
+
+export { translationAgent }

--- a/app/src/mastra/registry/agents/translate-agent/translate-agent.ts
+++ b/app/src/mastra/registry/agents/translate-agent/translate-agent.ts
@@ -1,0 +1,22 @@
+import 'dotenv/config';
+import { Agent } from '@mastra/core/agent';
+import { Memory } from '@mastra/memory';
+import { LibSQLStore } from '@mastra/libsql';
+import { google } from '@ai-sdk/google';
+
+export const translationAgent = new Agent({
+  name: 'Translation Assistant',
+  instructions: `
+You are a translation assistant.
+Your task is to correct the input text in its original language
+and then translate it into the requested language without rephrasing.
+Return only the translated text, without the original text,
+as plain text without Markdown.
+`,
+  memory: new Memory({
+    storage: new LibSQLStore({
+      url: 'file:../mastra.db',
+    }),
+  }),
+  model: google('gemini-2.5-flash-preview-04-17'),
+});

--- a/app/src/mastra/registry/agents/translate-agent/translate.yaml
+++ b/app/src/mastra/registry/agents/translate-agent/translate.yaml
@@ -1,0 +1,10 @@
+name: Translation Assistant
+description: |
+  Translation Agent for correcting and translating text
+tags:
+  - agent
+  - translation
+  - mastra
+exports:
+  - translationAgent
+author: mastra-ai

--- a/registry.json
+++ b/registry.json
@@ -73,5 +73,22 @@
       "zod"
     ],
     "envs": []
+  },
+  "translate-agent": {
+    "type": "agents",
+    "name": "translate-agent",
+    "files": [
+      "app/src/mastra/registry/agents/translate-agent/translate-agent.ts",
+      "app/src/mastra/registry/agents/translate-agent/index.ts",
+      "app/src/mastra/registry/agents/translate-agent/translate.yaml"
+    ],
+    "dependencies": [
+      "dotenv",
+      "@mastra/core",
+      "@mastra/memory",
+      "@mastra/libsql",
+      "@ai-sdk/google"
+    ],
+    "envs": []
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -73,22 +73,5 @@
       "zod"
     ],
     "envs": []
-  },
-  "translate-agent": {
-    "type": "agents",
-    "name": "translate-agent",
-    "files": [
-      "app/src/mastra/registry/agents/translate-agent/translate-agent.ts",
-      "app/src/mastra/registry/agents/translate-agent/index.ts",
-      "app/src/mastra/registry/agents/translate-agent/translate.yaml"
-    ],
-    "dependencies": [
-      "dotenv",
-      "@mastra/core",
-      "@mastra/memory",
-      "@mastra/libsql",
-      "@ai-sdk/google"
-    ],
-    "envs": []
   }
 }


### PR DESCRIPTION
## Summary
- introduce Translation Assistant agent with Google model and LibSQL memory
- add translate-agent metadata
- register translate-agent in `registry.json`

## Testing
- `npm test` *(fails: no test specified)*
- `npm test` in `test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f51f1a3c083318f40a309c9912191