### PR TITLE
Support multiple AI providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This script will:
 - Scan all agent, workflow, tool, etc. folders in the given path
 - List files (excluding ignored extensions, see `settings.json`)
 - Extract external dependencies and used environment variables
+- Detect the AI providers used and add an `aiprovider` array
 - Generate a `registry.json` file at the project root
 
 ## ⚙️ Configuration
@@ -151,6 +152,7 @@ Ce script va :
 - Parcourir tous les dossiers d’agents, workflows, tools, etc. dans le chemin indiqué
 - Lister les fichiers (hors extensions ignorées, voir `settings.json`)
 - Extraire les dépendances externes et variables d’environnement utilisées
+- Détecter les providers IA et ajouter le champ `aiprovider` (tableau)
 - Générer un fichier `registry.json` à la racine du projet
 
 ## ⚙️ Configuration

--- a/docs/src/pages/docs/cli.md
+++ b/docs/src/pages/docs/cli.md
@@ -58,7 +58,7 @@ Generate a `registry.json` file from a local folder containing your agents. The 
 npx tsai-registry build ./my-agents
 ```
 
-The command iterates through the `agents`, `workflows` and `tools` subfolders and gathers the files needed for each entry. It ignores extensions listed in `build.ignoreExtensions` from `settings.json`.
+The command iterates through the `agents`, `workflows` and `tools` subfolders and gathers the files needed for each entry. It detects the AI providers used in the source files and stores them in the `aiprovider` array. It also ignores extensions listed in `build.ignoreExtensions` from `settings.json`.
 
 ## `settings.json`
 

--- a/registry.json
+++ b/registry.json
@@ -4,8 +4,8 @@
     "name": "weather-agent",
     "files": [
       "app/src/mastra/registry/agents/weather-agent/weather-agent.ts",
-      "app/src/mastra/registry/agents/weather-agent/weather-tool.ts",
-      "app/src/mastra/registry/agents/weather-agent/index.ts"
+      "app/src/mastra/registry/agents/weather-agent/index.ts",
+      "app/src/mastra/registry/agents/weather-agent/weather-tool.ts"
     ],
     "dependencies": [
       "@ai-sdk/openai",
@@ -14,7 +14,52 @@
       "@mastra/libsql",
       "zod"
     ],
-    "envs": []
+    "envs": [],
+    "aiprovider": [
+      "openai"
+    ]
+  },
+  "firecrawl-agent": {
+    "type": "agents",
+    "name": "firecrawl-agent",
+    "files": [
+      "app/src/mastra/registry/agents/firecrawl-agent/index.ts",
+      "app/src/mastra/registry/agents/firecrawl-agent/web-agent.ts"
+    ],
+    "dependencies": [
+      "@mastra/core",
+      "@ai-sdk/openai",
+      "@mastra/memory",
+      "@mastra/libsql",
+      "@mastra/mcp"
+    ],
+    "envs": [
+      "FIRECRAWL_API_KEY"
+    ],
+    "aiprovider": [
+      "openai"
+    ]
+  },
+  "exa-agent": {
+    "type": "agents",
+    "name": "exa-agent",
+    "files": [
+      "app/src/mastra/registry/agents/exa-agent/index.ts",
+      "app/src/mastra/registry/agents/exa-agent/web-agent.ts"
+    ],
+    "dependencies": [
+      "@mastra/core",
+      "@ai-sdk/openai",
+      "@mastra/memory",
+      "@mastra/libsql",
+      "@mastra/mcp"
+    ],
+    "envs": [
+      "EXA_API_KEY"
+    ],
+    "aiprovider": [
+      "openai"
+    ]
   },
   "google-search-agent": {
     "type": "agents",
@@ -35,42 +80,9 @@
     "envs": [
       "GOOGLE_API_KEY",
       "GOOGLE_CX"
-    ]
-  },
-  "firecrawl-agent": {
-    "type": "agents",
-    "name": "firecrawl-agent",
-    "files": [
-      "app/src/mastra/registry/agents/firecrawl-agent/index.ts",
-      "app/src/mastra/registry/agents/firecrawl-agent/web-agent.ts"
     ],
-    "dependencies": [
-      "@mastra/core",
-      "@ai-sdk/openai",
-      "@mastra/memory",
-      "@mastra/libsql",
-      "@mastra/mcp"
-    ],
-    "envs": [
-      "FIRECRAWL_API_KEY"
-    ]
-  },
-  "exa-agent": {
-    "type": "agents",
-    "name": "exa-agent",
-    "files": [
-      "app/src/mastra/registry/agents/exa-agent/index.ts",
-      "app/src/mastra/registry/agents/exa-agent/web-agent.ts"
-    ],
-    "dependencies": [
-      "@mastra/core",
-      "@ai-sdk/openai",
-      "@mastra/memory",
-      "@mastra/libsql",
-      "@mastra/mcp"
-    ],
-    "envs": [
-      "EXA_API_KEY"
+    "aiprovider": [
+      "google"
     ]
   },
   "translate-agent": {
@@ -87,6 +99,9 @@
       "@mastra/libsql",
       "@ai-sdk/google"
     ],
-    "envs": []
+    "envs": [],
+    "aiprovider": [
+      "google"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- detect all AI providers from source imports
- store providers array in `aiprovider` field
- document provider array in README and CLI docs
- regenerate registry entries with provider arrays

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684fdd25e0b8833193a52ffa75d62151