### PR TITLE
Add local path override from settings file

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -72,6 +72,26 @@ async function handleEnvVariables(envs: string[] | undefined) {
 
 yargs(hideBin(process.argv))
   .command(
+    'init',
+    'Create a local settings-registry.json file',
+    () => {},
+    async () => {
+      const defaultPath = 'src/mastra/registry';
+      const input = await prompt(`Local registry path [${defaultPath}]: `);
+      const localPath = input.trim() || defaultPath;
+      const filePath = path.join(process.cwd(), 'settings-registry.json');
+      if (fs.existsSync(filePath)) {
+        const overwrite = (await prompt('settings-registry.json already exists. Overwrite? (y/N): ')).trim().toLowerCase();
+        if (overwrite !== 'y') {
+          console.log('Aborted.');
+          return;
+        }
+      }
+      fs.writeFileSync(filePath, JSON.stringify({ settings: { local: localPath } }, null, 2));
+      console.log(`settings-registry.json written to ${filePath}`);
+    }
+  )
+  .command(
     'settings',
     'Affiche les paramètres de configuration',
     () => {},

--- a/cli/utils.ts
+++ b/cli/utils.ts
@@ -3,11 +3,18 @@ import path from 'path';
 
 export async function loadSettings(settingsPath?: string): Promise<any> {
   let data: string;
+  let overrideLocalPath: string | undefined;
+
   if (!settingsPath) {
+    const localOverride = path.join(process.cwd(), 'settings-registry.json');
+    if (fs.existsSync(localOverride)) {
+      overrideLocalPath = JSON.parse(fs.readFileSync(localOverride, 'utf-8')).settings?.local;
+    }
     settingsPath = process.env.TSAR_SETTINGS_URL ||
       "https://raw.githubusercontent.com/aidalinfo/tsai-registry/refs/heads/main/settings.json";
   }
-  if (settingsPath.startsWith("http://") || settingsPath.startsWith("https://")) {
+
+  if (settingsPath.startsWith('http://') || settingsPath.startsWith('https://')) {
     const res = await fetch(settingsPath);
     if (!res.ok) throw new Error(`Erreur lors du chargement distant: ${res.statusText}`);
     data = await res.text();
@@ -16,9 +23,15 @@ export async function loadSettings(settingsPath?: string): Promise<any> {
       ? settingsPath
       : path.join(process.cwd(), settingsPath);
     if (!fs.existsSync(resolvedPath)) throw new Error(`Fichier introuvable: ${resolvedPath}`);
-    data = fs.readFileSync(resolvedPath, "utf-8");
+    data = fs.readFileSync(resolvedPath, 'utf-8');
   }
-  return JSON.parse(data);
+
+  const base = JSON.parse(data);
+  if (overrideLocalPath) {
+    base.settings = base.settings || {};
+    base.settings.local = overrideLocalPath;
+  }
+  return base;
 }
 
 export async function loadRegistry(registryPath: string, settingsUrl?: string): Promise<any> {


### PR DESCRIPTION
## Summary
- default init path is `src/mastra/registry`
- allow overriding the registry path via `settings-registry.json`

## Testing
- `bun run build`
- `bun run dist/index.js settings`
- `bun run dist/index.js init`

------
https://chatgpt.com/codex/tasks/task_e_684ffce68b5c8331a09e5c18a2ac8123